### PR TITLE
Fix Woordwaark URL parameters in StatsModal.tsx

### DIFF
--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -103,7 +103,7 @@ export const StatsModal = ({
               window.open(
                 'https://woordwaark.nl/woordenboek?query=' +
                   solution +
-                  '&languages[]=2&dictionaries[]=4&dictionaries[]=8&exact=false'
+                  '&language_ids[]=2&dictionary_ids[]=4&dictionary_ids[]=8&exact=false'
               )
             }}
           >


### PR DESCRIPTION
Woordwaark was recently updated, and the URL parameters are now slightly different. I've updated the keys in StatsModal.tsx so the link to Woordwaark to look up a word will again work as intended. Specifically, languages[]= and dictionaries[]= were changed to language_ids[]= and dictionary_ids[]=